### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,9 @@ Error:
 
 Fix it by issuing the below commands, in turn either installing or downgrading libcrypto.  The error comes from an incompatibility with the newer version of libcrypto.  Most older projects have this same bug.  
 ```
-wget http://ftp.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.24-9_amd64.udeb  
-dpkg -i libc6-udeb_2.24-9_amd64.udeb  
-wget http://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libcrypto1.0.2-udeb_1.0.2k-1_amd64.udeb  
-dpkg -i libcrypto1.0.2-udeb_1.0.2k-1_amd64.udeb  
-rm libc6-udeb_2.24-9_amd64.udeb  
-rm libcrypto1.0.2-udeb_1.0.2k-1_amd64.udeb  
+wget http://ftp.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.24-12_amd64.udeb http://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libcrypto1.0.2-udeb_1.0.2l-2_amd64.udeb  
+sudo dpkg -i libc6-udeb_2.24-12_amd64.udeb libcrypto1.0.2-udeb_1.0.2l-2_amd64.udeb  
+rm libc6-udeb_2.24-12_amd64.udeb libcrypto1.0.2-udeb_1.0.2l-2_amd64.udeb  
 ```
 -----
 Encrypting and Decrypting a vanitygen or oclvanitygen private key  


### PR DESCRIPTION
update libc6-udeb and libcrypto1.0.2-udeb packages names to match to their most recent versions
old packets are unavailable on http://ftp.us.debian.org