### PR TITLE
Fixing some README links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Error:
 
 Fix it by issuing the below commands, in turn either installing or downgrading libcrypto.  The error comes from an incompatibility with the newer version of libcrypto.  Most older projects have this same bug.  
 ```
-wget http://ftp.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.24-17_amd64.udeb http://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libcrypto1.0.2-udeb_1.0.2l-2_amd64.udeb  
-sudo dpkg -i libc6-udeb_2.24-17_amd64.udeb libcrypto1.0.2-udeb_1.0.2l-2_amd64.udeb  
-rm libc6-udeb_2.24-17_amd64.udeb libcrypto1.0.2-udeb_1.0.2l-2_amd64.udeb  
+wget http://ftp.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.26-4_amd64.udeb http://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libcrypto1.0.2-udeb_1.0.2l-2+deb9u1_amd64.udeb  
+sudo dpkg -i libc6-udeb_2.26-4_amd64.udeb libcrypto1.0.2-udeb_1.0.2l-2+deb9u1_amd64.udeb  
+rm libc6-udeb_2.26-4_amd64.udeb libcrypto1.0.2-udeb_1.0.2l-2+deb9u1_amd64.udeb  
 ```
 -----
 Encrypting and Decrypting a vanitygen or oclvanitygen private key  


### PR DESCRIPTION
I changed the links to libcrypto and libc6 in the README, under the section to fix the libcrypto.so.1.0.2 error, since the files were no longer found on the server.  
Using these packages worked to fix the error on my Ubuntu computer.