### PR TITLE
Add support for NetBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ ifeq ($(PLATFORM),Darwin)
 	OPENCL_LIBS=-framework OpenCL
 	LIBS+=-L/usr/local/opt/openssl/lib
 	CFLAGS+=-I/usr/local/opt/openssl/include
+else ifeq ($(PLATFORM),NetBSD)
+	LIBS+=`pcre-config --libs`
+	CFLAGS+=`pcre-config --cflags`
 else
 	OPENCL_LIBS=-lOpenCL
 endif


### PR DESCRIPTION
On NetBSD, ``gmake`` fails because we need information from ``pcre-config``, so I added the necessary parts to conditionally include this so that ``gmake`` builds ``vanitygen-plus`` successfully on NetBSD.