### PR TITLE
Fix cl.exe compiling error C3688

### DIFF
--- a/oclengine.c
+++ b/oclengine.c
@@ -307,9 +307,9 @@ vg_ocl_dump_info(vg_ocl_context_t *vocp)
 	       vg_ocl_device_getstr(did, CL_DEVICE_PROFILE));
 	fprintf(stderr, "Version: %s\n",
 	       vg_ocl_device_getstr(did, CL_DEVICE_VERSION));
-	fprintf(stderr, "Max compute units: %"PRSIZET"d\n",
+	fprintf(stderr, "Max compute units: %" PRSIZET "d\n",
 	       vg_ocl_device_getsizet(did, CL_DEVICE_MAX_COMPUTE_UNITS));
-	fprintf(stderr, "Max workgroup size: %"PRSIZET"d\n",
+	fprintf(stderr, "Max workgroup size: %" PRSIZET "d\n",
 	       vg_ocl_device_getsizet(did, CL_DEVICE_MAX_WORK_GROUP_SIZE));
 	fprintf(stderr, "Global memory: %ld\n",
 	       vg_ocl_device_getulong(did, CL_DEVICE_GLOBAL_MEM_SIZE));
@@ -790,7 +790,7 @@ vg_ocl_load_program(vg_context_t *vcp, vg_ocl_context_t *vocp,
 		buf = (char *) malloc(szr);
 		if (!buf) {
 			fprintf(stderr,
-				"WARNING: Could not allocate %"PRSIZET"d bytes "
+				"WARNING: Could not allocate %" PRSIZET "d bytes "
 				"for CL binary\n",
 			       szr);
 			goto out;
@@ -838,7 +838,7 @@ vg_ocl_load_program(vg_context_t *vcp, vg_ocl_context_t *vocp,
 				fprintf(stderr,
 					"WARNING: short write on CL kernel "
 					"binary file: expected "
-					"%"PRSIZET"d, got %"PRSIZET"d\n",
+					"%" PRSIZET "d, got %" PRSIZET "d\n",
 					szr, sz);
 				unlink(bin_name);
 			}


### PR DESCRIPTION
oclengine.c(310) causes error C3688

my env:
win10pro, Microsoft(R) C/C++ Optimizing Compiler Version 19.13.26128 for x86

Makefile.Win32 is:
oclengine.obj: oclengine.c
	@$(CC) /nologo $(CFLAGS_BASE) $(OPENCL_INCLUDE) /c /Tpoclengine.c /Fo$@

 /Tp option is for cpp (not c) compliing.

In case of cpp compiling, I confirmed the cl.exe treats:

OK:
printf("ABC" "LMN" "XYX");

OK:
printf("ABC""LMN""XYX");

OK:
#define LMN "LMN"
printf("ABC" LMN "XYZ");

NG error C3688:
#define LMN "LMN"
printf("ABC"LMN"XYZ");



So I think it would be safer to put a space between being concatened string-literals. 



--- compile error ---
oclengine.c
oclengine.c(310): error C3688: リテラル サフィックス 'PRSIZET' が無効です。リテラル演算子またはリテラル演算子テンプレート 'operator ""PRSIZET' が見つかりません
oclengine.c(310): error C2664: 'int fprintf(FILE *const ,const char *const ,...)': 引数 2 を '::size_t' から 'const char *const ' へ変換できません。
oclengine.c(311): note: 整数型からポインター型への変換には reinterpret_cast、C スタイル キャストまたは関数スタイル キャストが必要です。
oclengine.c(312): error C3688: リテラル サフィックス 'PRSIZET' が無効です。リテラル演算子またはリテラル演算子テンプレート 'operator ""PRSIZET' が見つかりません
oclengine.c(312): error C2664: 'int fprintf(FILE *const ,const char *const ,...)': 引数 2 を '::size_t' から 'const char *const ' へ変換できません。
oclengine.c(313): note: 整数型からポインター型への変換には reinterpret_cast、C スタイル キャストまたは関数スタイル キャストが必要です。
oclengine.c(314): warning C4477: 'fprintf' : 書式文字列 '%ld' には、型 'long' の引数が必要ですが、可変個引数 1 は型 'cl_ulong' です
oclengine.c(314): note: 書式文字列に '%lld' を使用することをお勧めします
oclengine.c(314): note: 書式文字列に '%I64d' を使用することをお勧めします
oclengine.c(316): warning C4477: 'fprintf' : 書式文字列 '%ld' には、型 'long' の引数が必要ですが、可変個引数 1 は型 'cl_ulong' です
oclengine.c(316): note: 書式文字列に '%lld' を使用することをお勧めします
oclengine.c(316): note: 書式文字列に '%I64d' を使用することをお勧めします
oclengine.c(794): error C3688: リテラル サフィックス 'PRSIZET' が無効です。リテラル演算子またはリテラル演算子テンプレート 'operator ""PRSIZET' が見つかりません
oclengine.c(792): error C2664: 'int fprintf(FILE *const ,const char *const ,...)': 引数 2 を '::size_t' から 'const char *const ' へ変換できません。
oclengine.c(795): note: 整数型からポインター型への変換には reinterpret_cast、C スタイル キャストまたは関数スタイル キャストが必要です。
oclengine.c(841): error C3688: リテラル サフィックス 'PRSIZET' が無効です。リテラル演算子またはリテラル演算子テンプレート 'operator ""PRSIZET' が見つかりません
oclengine.c(838): error C2664: 'int fprintf(FILE *const ,const char *const ,...)': 引数 2 を '::size_t' から 'const char *const ' へ変換できません。
oclengine.c(842): note: 整数型からポインター型への変換には reinterpret_cast、C スタイル キャストまたは関数スタイル キャストが必要です。
oclengine.c(1207): warning C4838: 'int' から '::size_t' への変換には縮小変換が必要です
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.13.26128\bin\HostX86\x86\cl.EXE"' : リターン コード '0x2'
Stop.