### PR TITLE
removing show loading status of patterns from file

### DIFF
--- a/util.c
+++ b/util.c
@@ -1157,7 +1157,6 @@ vg_read_file(FILE *fp, char ***result, int *rescount)
 					}
 					patterns[npatterns] = pat;
 					npatterns++;
-					fprintf(stderr,	"\rLoading Pattern #%d: %s", npatterns, pat);
 					pat = NULL;
 				}
 			}
@@ -1172,6 +1171,5 @@ vg_read_file(FILE *fp, char ***result, int *rescount)
 
 	*result = patterns;
 	*rescount = npatterns;
-	fprintf(stderr,	"\n");
 	return ret;
 }


### PR DESCRIPTION
by showing loading status of patterns from file taking extra 5 to 15 seconds time to start the program based on number of patterns (ie: 100000 patterns).
so it's better to remove that the showing patterns to make program to start faster while using patterns from file to 1 to 3 seconds only.

please accept it.
Thank you.