### PR TITLE
Add PepeCoin / Memetic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Current List of Available Coins for Address Generation
 |NYAN | Nyancoin | K  |
 |OK | OK Cash | P  |
 |OMC | Omnicoin | o  |
+|PEPE | PepeCoin / Memetic | P |
 |PIGGY | Piggycoin | p  |
 |PINK | Pinkcoin | 2  |
 |PIVX | PIVX | D  |

--- a/keyconv.c
+++ b/keyconv.c
@@ -1216,6 +1216,14 @@ main(int argc, char **argv)
 					privtype_opt = 239;
 					break;
 			}
+			else
+			if (strcmp(optarg, "PEPE")== 0) {
+				fprintf(stderr,
+					"Decrypting PepeCoin / Memetic Address\n");
+					addrtype_opt = 55;
+					privtype_opt = 153;
+					break;
+			}
 			break;
 
 /*END ALTCOIN GENERATOR*/

--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -267,6 +267,7 @@ main(int argc, char **argv)
 					"NYAN : Nyancoin : K\n"
 					"OK : OK Cash : P\n"
 					"OMC : Omnicoin : o\n"
+					"PEPE: PepeCoin / Memetic : P\n"
 					"PIGGY : Piggycoin : p\n"
 					"PINK : Pinkcoin : 2\n"
 					"PIVX : PIVX : D\n"
@@ -1300,6 +1301,14 @@ main(int argc, char **argv)
 					"Generating MNC Testnet Address\n");
 					addrtype = 111;
 					privtype = 239;
+					break;
+			}
+			else
+			if (strcmp(optarg, "PEPE")== 0) {
+				fprintf(stderr,
+					"Generating PepeCoin / Memetic Address\n");
+					addrtype = 55;
+					privtype = 153;
 					break;
 			}
 			break;

--- a/vanitygen.c
+++ b/vanitygen.c
@@ -530,6 +530,7 @@ main(int argc, char **argv)
 					"NYAN : Nyancoin : K\n"
 					"OK : OK Cash : P\n"
 					"OMC : Omnicoin : o\n"
+					"PEPE: PepeCoin / Memetic : P\n"
 					"PIGGY : Piggycoin : p\n"
 					"PINK : Pinkcoin : 2\n"
 					"PIVX : PIVX : D\n"
@@ -1573,6 +1574,14 @@ main(int argc, char **argv)
 					"Generating MNC Testnet Address\n");
 					addrtype = 111;
 					privtype = 239;
+					break;
+			}
+			else
+			if (strcmp(optarg, "PEPE")== 0) {
+				fprintf(stderr,
+					"Generating PEPE / MEME Address\n");
+					addrtype = 55;
+					privtype = 153;
 					break;
 			}
 			break;


### PR DESCRIPTION
Add support for PepeCoin / Memetic, listed on CoinMarketCap and Bittrex since early 2016.
