### PR TITLE
make "-C LIST" usage example utilize correct binary name

### DIFF
--- a/vanitygen.c
+++ b/vanitygen.c
@@ -439,7 +439,7 @@ main(int argc, char **argv)
 			/* Start AltCoin Generator */
 			if (strcmp(optarg, "LIST")== 0) {
 				fprintf(stderr,
-					"Usage example \"./oclvanitygen -C LTC Lfoo\"\n"
+					"Usage example \"%s -C LTC Lfoo\"\n"
 					"List of Available Alt-Coins for Address Generation\n"
 					"---------------------------------------------------\n"
 					"Argument(UPPERCASE) : Coin : Address Prefix\n"
@@ -568,7 +568,8 @@ main(int argc, char **argv)
 					"YTN : Yenten : Y\n"
 					"ZNY : BitZeny : Z\n"
 					"ZOOM : Zoom coin : i\n"
-					"ZRC : Ziftrcoin : Z\n"
+					"ZRC : Ziftrcoin : Z\n",
+					argv[0]
 					);
 					return 1;
 			}


### PR DESCRIPTION
the "-C LIST" parameter currently outputs the incorrect binary name, and is hardcoded. the proposed code change reflects argv[0] -> %s on the command usage print to stderr.  my previous pull request patched the same issue in keyconv.c