### PR TITLE
Added StakeCube Coin and updated macOS compiling instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -32,19 +32,13 @@ prompt window, and run:
 
 nmake /fMakefile.Win32 vanitygen.exe oclvanitygen.exe
 
-MacOS:
+macOS:
 Install Homebrew
 `ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go/install)"`
 
 Install pcre, pcre++, and openSSL using Homebrew
 brew install pcre pcre++ openssl
 
-In Makefile replace LIBS, and CFLAGS lines with the lines below:
-LIBS= -lpcre -lcrypto -lm -lpthread
-INCPATHS=-I$(shell brew --prefix)/include -I$(shell brew --prefix openssl)/include
-LIBPATHS=-L$(shell brew --prefix)/lib -L$(shell brew --prefix openssl)/lib
-CFLAGS=-ggdb -O3 -Wall -Qunused-arguments $(INCPATHS) $(LIBPATHS)
-
-Compile binaries executing the following:
-`make all`
+Compile macOS binaries executing the following:
+`make -f Makefile.macos all`
 

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,9 +1,10 @@
-####
-## If compiling on a mac run `make -f Makefile.macos all`
-####
-LIBS=-lpcre -lcrypto -lm -lpthread
-CFLAGS=-ggdb -O3 -Wall
+# before compiling binaries make sure you have Homebrew installed and 
+# you executed `brew install pcre pcre++ openssl` 
 
+LIBS= -lpcre -lcrypto -lm -lpthread
+INCPATHS=-I$(shell brew --prefix)/include -I$(shell brew --prefix openssl)/include
+LIBPATHS=-L$(shell brew --prefix)/lib -L$(shell brew --prefix openssl)/lib
+CFLAGS=-ggdb -O3 -Wall -Qunused-arguments $(INCPATHS) $(LIBPATHS)
 OBJS=vanitygen.o oclvanitygen.o oclvanityminer.o oclengine.o keyconv.o pattern.o util.o groestl.o
 PROGS=vanitygen keyconv oclvanitygen oclvanityminer
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Current List of Available Coins for Address Generation
 |ROI | ROIcoin | R  |
 |RVN | Ravencoin | R |
 |SCA | Scamcoin | S  |
+|SCC | StakeCube Coin | s  |
 |SDC | Shadowcoin | S  |
 |SKC | Skeincoin | S  |
 |SPR | Spreadcoin | S  |

--- a/keyconv.c
+++ b/keyconv.c
@@ -189,6 +189,7 @@ main(int argc, char **argv)
 					"ROI : ROIcoin : R\n"
 					"RVN : Ravencoin : R\n"
 					"SCA : Scamcoin : S\n"
+					"SCC : StakeCube Coin : s\n"
 					"SDC : Shadowcoin : S\n"
 					"SKC : Skeincoin : S\n"
 					"SPR : Spreadcoin : S\n"
@@ -1214,6 +1215,14 @@ main(int argc, char **argv)
 					"Decrypting MNC Testnet Address\n");
 					addrtype_opt = 111;
 					privtype_opt = 239;
+					break;
+			}
+			else
+			if (strcmp(optarg, "SCC")== 0) {
+				fprintf(stderr,
+					"Decrypting SCC Address\n");
+					addrtype_opt = 125;
+					privtype_opt = 253;
 					break;
 			}
 			break;

--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -283,6 +283,7 @@ main(int argc, char **argv)
 					"ROI : ROIcoin : R\n"
 					"RVN : Ravencoin : R\n"
 					"SCA : Scamcoin : S\n"
+					"SCC : StakeCube Coin : s\n"
 					"SDC : Shadowcoin : S\n"
 					"SKC : Skeincoin : S\n"
 					"SPR : Spreadcoin : S\n"
@@ -1300,6 +1301,14 @@ main(int argc, char **argv)
 					"Generating MNC Testnet Address\n");
 					addrtype = 111;
 					privtype = 239;
+					break;
+			}
+			else
+			if (strcmp(optarg, "SCC")== 0) {
+				fprintf(stderr,
+					"Generating SCC Address\n");
+					addrtype = 125;
+					privtype = 253;
 					break;
 			}
 			break;

--- a/vanitygen.c
+++ b/vanitygen.c
@@ -546,6 +546,7 @@ main(int argc, char **argv)
 					"ROI : ROIcoin: R\n"
 					"RVN : Ravencoin : R\n"
 					"SCA : Scamcoin : S\n"
+					"SCC : StakeCube Coin : s\n"
 					"SDC : Shadowcoin : S\n"
 					"SKC : Skeincoin : S\n"
 					"SPR : Spreadcoin : S\n"
@@ -1573,6 +1574,14 @@ main(int argc, char **argv)
 					"Generating MNC Testnet Address\n");
 					addrtype = 111;
 					privtype = 239;
+					break;
+			}
+			else
+			if (strcmp(optarg, "SCC")== 0) {
+				fprintf(stderr,
+					"Generating SCC Address\n");
+					addrtype = 125;
+					privtype = 253;
 					break;
 			}
 			break;


### PR DESCRIPTION
Added and tested (sStaKErsNy1KDsYjNPugZZu8vRxrmsK2W1) using `staker` as vanity test for  SCC - StakeCube Coin vanity address generation

I also updated the macOS compiling instructions so users don't have to make edits to the original `Makefile` in order to compile the binaries on macOS, by supplying a `Makefile.macos` file

Thanks for your consideration

👍🏼